### PR TITLE
Get rid of input for email

### DIFF
--- a/src/routes/Footer.svelte
+++ b/src/routes/Footer.svelte
@@ -12,10 +12,9 @@
 				<p>subscribe for exclusive</p>
 				<p>updates on our events</p>
 			</div>
-			<div class="flex flex-col justify-end flex-1 md:flex-none md:flex-row md:items-end">
-				<div class="w-full "><Input class="w-full" placeholder="Email" /></div>
-				<div class="mt-2 ml-2">
-					<Button href="https://1rg.eo.page/subscribe" class="px-1 mt-5 text-4xl uppercase " hoverColor="white">subscribe</Button>
+			<div class="flex flex-col flex-1 md:flex-none md:flex-row md:items-end">
+				<div class="mt-2">
+					<Button href="https://1rg.space/subscribe" class="px-1 mt-5 text-4xl uppercase " hoverColor="white">join the list</Button>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
# The problem

After I enter my email 
<img width="689" alt="Screen Shot 2023-04-26 at 3 42 00 PM" src="https://user-images.githubusercontent.com/34720/234685226-214575b0-f428-4ee7-b078-8c9962c7d814.png">

I get redirected to a form that requires me to put it in again and my name
<img width="791" alt="Screen Shot 2023-04-26 at 3 42 46 PM" src="https://user-images.githubusercontent.com/34720/234685342-60cb7c96-3201-4bfc-bc5c-1969a4e45c1d.png">

This is because of a limitation with the Email Octopus forms - if I embed their form in the page it doesn't match our style, and we also want to collect people's names as well...

This is bad UX that loses us some subscribers who put in an email and click subscribe and don't notice there's a second form to fill out (I've had conversations with several people who didn't fully fill it out).

# The solution

In lieu of hacking together the form, I made the button say "join the list" and take you to the form.

<img width="661" alt="Screen Shot 2023-04-26 at 3 45 13 PM" src="https://user-images.githubusercontent.com/34720/234685871-b4015212-ed4e-4f8c-868c-2407a0fe306a.png">
