### PR TITLE
Embiggen the events embed

### DIFF
--- a/src/routes/events/+page.svelte
+++ b/src/routes/events/+page.svelte
@@ -11,14 +11,13 @@
 
 <Heading>Events Events Events</Heading>
 
-<section class="flex flex-col md:px-20 md:py-16 bg-white overflow-auto">
+<section class="flex flex-col overflow-auto h-[50rem]">
 	<iframe
 		title="1RG Public Calendar"
 		src="https://lu.ma/embed/calendar/cal-wYZCgwOcJN8kiNH/events"
 		width="100%"
-		height="500"
+		height="100%"
 		frameborder="0"
-		style="border: 1px solid #bfcbda88; border-radius: 4px;"
 		allowfullscreen="false"
 		aria-hidden="false"
 		tabindex="0"


### PR DESCRIPTION
- Removes all padding, most of this is handled quite nicely by lu.ma
- Puts more events on the page so users don't have to scroll

### Screenshot
<img width="1792" alt="Screenshot 2024-05-21 at 3 38 01 PM" src="https://github.com/1rglabs/1rg.space/assets/5672810/bfe8a858-44c8-4161-b247-e433e4b8053b">

### Caveats

Unsure if this will work quite as nicely if there are no events... But I assume lu.ma has a system for that?