### PR TITLE
40 improve membership mobile view

### DIFF
--- a/src/lib/components/MembershipTierCard.svelte
+++ b/src/lib/components/MembershipTierCard.svelte
@@ -7,23 +7,28 @@
 
 </script>
 
-<div class="grid grid-rows-6 p-8 border-2 rounded-md border-slate-300 shadow">
-    <div class="row-span-1 text-center mt-4 font-bold uppercase text-xl lg:text-2xl tracking-wide text-mediumorchid">{tier}</div>
-    <div class="row-span-2 text-center font text-m lg:text-lg">
+<div class="grid grid-rows-7 p-2 md:p-8 border-2 rounded-md border-slate-300 shadow">
+    <div class="row-span-1 text-center mt-4 font-bold uppercase text-lg lg:text-xl tracking-wide text-mediumorchid">{tier}</div>
+    <div class="row-span-2 text-center font text-sm lg:text-lg">
         {description}
     </div>
-    <div class="row-span-2 mt-2 font text-m lg:text-lg">
+    <div class="row-span-3 font text-sm lg:text-lg">
         What's included:
         <ul class="list-disc list-inside ml-4">
-            <li>Community events every Tuesday</li>
-            <li>Monthly Community Dinner</li>
             <li>{access}</li>
-            <li>Any future community events</li>
-            <li>Open guest policy</li>
+            {#if tier === "Dedicated Desk"}
+                <li>A personal set of keys</li>
+            {/if}
+            <li>Invitations to private events</li>
+            <li>Priority access to our monthly Community Dinners</li>
+            <li>Discounted rates for evening/weekend space rentals</li>
+            {#if tier === "Dedicated Desk" || tier === "Hot Desk"}
+                <li>One complimentary event per month</li>
+            {/if}
         </ul>
     </div>
     <div class="row-span-1 mt-4 text-center">
-        <p class="font-bold text-lg lg:text-xl">${price}/month + HST</p>
-        <p class="text-m lg:text-lg">{cancellationPolicy}</p>
+        <p class="font-bold text-m lg:text-xl">${price}/month + HST</p>
+        <p class="text-sm lg:text-lg">{cancellationPolicy}</p>
     </div>
 </div>

--- a/src/routes/memberships/+page.svelte
+++ b/src/routes/memberships/+page.svelte
@@ -7,17 +7,17 @@
 
 	let membershipCardCopy = {
 		"Community Membership": {
-			description: "You're part of the 1RG community, but don't need a full-time workspace. You'll get access to private events, and one day a week of your choosing to use the space for co-working, or just to drop by!",
+			description: "You're part of the 1RG community, but don't need a full-time workspace.",
 			access: "Access any 1 day a week 8am-10pm",
 			price: "100"
 		},
 		"Hot Desk": {
-			description: "1RG is part of your routine but you're not working here every day. You'll get access during business hours and can use any of the available desks. This is for people that want to be engaged in the community and love working from here, but don't need a committed office.",
+			description: "1RG is part of your routine, but don't need a committed office.",
 			access: "Access Mon-Fri 8am-10pm",
 			price: "300"
 		},
 		"Dedicated Desk": {
-			description: "1RG is your permanent office. You'll get 24/7 access with keys, a dedicated desk, and the ability to throw events in the space (up to 30 people). This is for people who want to actively engage in helping shape the space and community.",
+			description: "1RG is your permanent office, and you're actively engaged in helping shape the space and community.",
 			access: "Access to 1RG 24/7",
 			price: "500",
 			cancellationPolicy: "6 months commitment required"
@@ -40,7 +40,7 @@
 	 -->
 	<div class="text-center flex flex-col items-center sticky top-0 md:relative">
 		<p class="flex flex-col justify-center text-xl font-semibold leading-10 tracking-widest text-center uppercase lg:leading-loose lg:text-2xl  text-mediumorchid">
-			<Button href="/book-a-tour" class="px-5 py-3 text-4xl uppercase">book a tour</Button>
+			<Button href="/book-a-tour" class="px-5 py-3 text-2xl md:text-4xl uppercase">book a tour</Button>
 		</p>
 	</div>
 

--- a/src/routes/memberships/+page.svelte
+++ b/src/routes/memberships/+page.svelte
@@ -31,21 +31,22 @@
 </svelte:head>
 
 <Heading>Memberships Memberships Memberships</Heading>
-<section class="flex flex-col my-24 p-8">
-	<div class="text-center flex flex-col items-center">
+<section class="flex flex-col my-24 p-2">
+	
+	<!-- <div class="text-center flex flex-col items-center">
 		<div class="text-2xl">Please,</div>
 		<h1 class="px-6 py-5 md:m-4 text-4xl mt-0 pt-0 font-black leading-tight md:text-6xl xl:text-8xl xl:leading-normal text-center uppercase">Seat yourself </h1>
 	</div>
-
-	<div class="grid grid-cols-1 lg:grid-cols-3 gap-8 mt-16 p-8">
-		{#each Object.entries(membershipCardCopy) as [tier, vals]}
-			<MembershipTierCard tier={tier} description={vals.description} access={vals.access} price={vals.price}></MembershipTierCard>
-		{/each}
-	</div>
-
-	<div class="text-center flex flex-col items-center mt-20">
+	 -->
+	<div class="text-center flex flex-col items-center sticky top-0 md:relative">
 		<p class="flex flex-col justify-center text-xl font-semibold leading-10 tracking-widest text-center uppercase lg:leading-loose lg:text-2xl  text-mediumorchid">
 			<Button href="/book-a-tour" class="px-5 py-3 text-4xl uppercase">book a tour</Button>
 		</p>
+	</div>
+
+	<div class="grid grid-cols-1 lg:grid-cols-3 gap-8 mt-16 p-1 md:p-8">
+		{#each Object.entries(membershipCardCopy) as [tier, vals]}
+			<MembershipTierCard tier={tier} description={vals.description} access={vals.access} price={vals.price}></MembershipTierCard>
+		{/each}
 	</div>
 </section>


### PR DESCRIPTION
Under Ray's recommendation I moved `Book a tour` to the top of the page and made it sticky when it's on mobile. The current version doesn't have _please, seat yourself_ which I honestly did like but might not look as good with the button. I left it in comments for now. Perhaps the button comes first? I don't know. I would also like to add a friends of 1RG call tp action but am unsure if having all on one page overloads it

#### Screenshots with:
##### desktop
<img width="1120" alt="Screenshot 2024-07-29 at 5 39 56 PM" src="https://github.com/user-attachments/assets/415693c0-77c9-435d-b0df-453da530ede2">

##### mobile
<img width="411" alt="Screenshot 2024-07-29 at 5 40 04 PM" src="https://github.com/user-attachments/assets/4c0b1441-6d82-4471-9ae7-dc800e70d268">

#### And without:
##### desktop
<img width="1123" alt="Screenshot 2024-07-29 at 5 40 38 PM" src="https://github.com/user-attachments/assets/c4cdb07c-acb5-4d28-8a65-1bc198315a58">

##### mobile
<img width="414" alt="Screenshot 2024-07-29 at 5 40 32 PM" src="https://github.com/user-attachments/assets/f914c530-950b-4d14-a10d-f13561c12f41">




I also readjusted the spacing of the cards. I think they look much better with smaller text and padding on mobile:

<img width="395" alt="Screenshot 2024-07-29 at 6 37 09 PM" src="https://github.com/user-attachments/assets/1816e7f7-86db-4cc9-bb0a-b900e8975e9e">

The alignment doesn't work as well on desktop but I think I am okay with it? Not sure what to do about it because the number of bullets is now different for each tier. See green line


<img width="1652" alt="Screenshot 2024-07-29 at 6 34 33 PM" src="https://github.com/user-attachments/assets/39d10b58-fdad-4dcf-a4d9-0e55a6aff3ad">
